### PR TITLE
Add warning about more than one interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ The plugin hooks into the `basic.publish` path, so expect a small
 throughput reduction when using this plugin, since it has to modify
 every message that crosses RabbitMQ.
 
+This plugin should not be enabled at the same time as any other 
+interceptors  that hook into the `basic.publish` process, such as 
+the  `rabbitmq-routing-node-stamp` plugin. Enabling more than one 
+interceptor that is registered to the `basic.publish` process will 
+cause all AMQP connections to fail when creating a new channel.
+
 If there's enough demand, we could add in the future a way for only
 time-stamping messages that crosses certain exchanges, say by applying
 policies.


### PR DESCRIPTION
Per [the documentation](https://github.com/rabbitmq/internals/blob/master/interceptors.md#interceptors) on interceptors, only a single interceptor can be active on an AMQP method. Failure to do so causes connections to crash (See [RabbitMQ #824](https://github.com/rabbitmq/rabbitmq-server/issues/824)).